### PR TITLE
Created Dockerfile and .dockerignore - issue #3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+/tests
+/resources/*
+README.md
+# LICENSE
+Dockerfile
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use most lightweight base image possible
+FROM alpine:latest
+
+# Install required packages for app to run
+RUN apk add --no-cache git ffmpeg python3 py3-pip
+#RUN apk add --no-cache git python3 py3-pip
+
+# Make app dir
+WORKDIR /app
+
+# Copy source files
+ADD . /app
+
+# Install Python dependencies using pip (if there will be any)
+#RUN pip install -r requirements.txt
+
+# Install Python dependencies using pip (hardcoded)
+RUN pip install ffmpeg python-ffmpeg pyyaml
+
+# Clear unwanted files and cleanup
+RUN apk del git \
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /root/.cache \
+    && rm -rf /app/.git
+
+# Set the default command to run your application (you have to mount video and yaml into /app/resources)
+CMD ["python3", "split.py"]


### PR DESCRIPTION
Hi Christian 👋,

I prepared a Dockerfile that allows you to build the image locally.  This should resolve #3 

The only comment I have is that in the `files.yml` file the output video is given without specifying a path - so it will drop into the root folder. When using Docker images, it is easier to mount one folder than several, so _I recommend adding, for example, `resources/` before the output file names_. Like this:

```yaml
input_file:
  name: "resources/test_video.mp4"

output_files:
  - name: "resources/first_5_seconds.mp4"
    start: "00:00:00"
    end: "00:00:05"
  - name: "resources/second_5_seconds.mp4"
    start: "00:00:04"
    end: "00:00:09.5"
  - name: "resources/middle_5_seconds.mp4"
    start: "00:00:02.5"
    end: "00:00:07.5"

```

In this case, we only mount one directory into which we drop the input files (video and `files.yml`) and after the Docker image has completed the task, we have the output files in the same directory on our local machine.

Usage:
```sh
# pwd
/home/veinar/auto-split
# ls -la ./resources
total 4092
drwxr-xr-x. 2 root root      45 Oct 25 00:39 .
drwxr-xr-x. 3 root root      41 Oct 25 00:35 ..
-rw-r--r--. 1 root root     292 Oct 25 00:36 files.yml
-rw-r--r--. 1 root root 4182252 Oct 25 00:36 test_video.mp4
# vi ./resources/files.yml
# docker run -v /home/veinar/auto-split/resources:/app/resources auto-split:latest
# ls -la ./resources/
total 10388
drwxr-xr-x. 2 root root     128 Oct 25 00:51 .
drwxr-xr-x. 3 root root      41 Oct 25 00:35 ..
-rw-r--r--. 1 root root     322 Oct 25 00:51 files.yml
-rw-r--r--. 1 root root 2023882 Oct 25 00:51 first_5_seconds.mp4
-rw-r--r--. 1 root root 2207315 Oct 25 00:51 middle_5_seconds.mp4
-rw-r--r--. 1 root root 2208588 Oct 25 00:51 second_5_seconds.mp4
-rw-r--r--. 1 root root 4182252 Oct 25 00:36 test_video.mp4
```

Building **(must be performed in root project dir where Dockerfile is located)**:
```sh
docker build . -t <image-name>:<tag>
```

Hope it solves your issue and my solution is explained clearly,
Regards,
Konrad

---
Checks:

- [X] There is a `Dockerfile` that allows you to run video splitting in a container,
- [X] Include only the bare minimum in the image (only python file and LICENSE are added, see `.dockerignore`),
- [X] Image is the lightest as it could be (~217 MB for now due to required `ffmpeg` dependency)